### PR TITLE
Bump hseeberger/scala-sbt

### DIFF
--- a/src/main/g8/docker-compose.yml
+++ b/src/main/g8/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     working_dir: /opt/$name;format="norm"$/app-backend/api/target/scala-2.11/
 
   sbt:
-    image: hseeberger/scala-sbt:11.0.2_2.12.8_1.2.8
+    image: hseeberger/scala-sbt:11.0.3_1.2.8_2.12.8
     depends_on:
       database:
         condition: service_healthy


### PR DESCRIPTION
👋 

To the most similar tag that works relative to the old one:

```
docker pull hseeberger/scala-sbt:11.0.2_2.12.8_1.2.8
> Error response from daemon: manifest for hseeberger/scala-sbt:11.0.2_2.12.8_1.2.8 not found
docker pull hseeberger/scala-sbt:11.0.3_1.2.8_2.12.8
> Status: Downloaded newer image for hseeberger/scala-sbt:11.0.3_1.2.8_2.12.8
```